### PR TITLE
Implement showdown phase with community cards and hand comparison display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,24 +8,13 @@
       "name": "poker-room-multiplayer",
       "version": "0.1.0",
       "dependencies": {
-        "@testing-library/dom": "^10.4.0",
-        "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.3.0",
-        "@testing-library/user-event": "^13.5.0",
         "axios": "^1.10.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.7.0",
         "react-scripts": "^5.0.1",
-        "socket.io-client": "^4.8.1",
-        "web-vitals": "^2.1.4"
+        "socket.io-client": "^4.8.1"
       }
-    },
-    "node_modules/@adobe/css-tools": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.3.tgz",
-      "integrity": "sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==",
-      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -3432,116 +3421,6 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
-      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "dequal": "^2.0.3"
-      }
-    },
-    "node_modules/@testing-library/jest-dom": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
-      "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@adobe/css-tools": "^4.4.0",
-        "aria-query": "^5.0.0",
-        "chalk": "^3.0.0",
-        "css.escape": "^1.5.1",
-        "dom-accessibility-api": "^0.6.3",
-        "lodash": "^4.17.21",
-        "redent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
-      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
-      "license": "MIT"
-    },
-    "node_modules/@testing-library/react": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
-      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": "^10.0.0",
-        "@types/react": "^18.0.0 || ^19.0.0",
-        "@types/react-dom": "^18.0.0 || ^19.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@testing-library/user-event": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
-      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": ">=7.21.4"
-      }
-    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -3559,12 +3438,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6238,12 +6111,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/css.escape": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "license": "MIT"
-    },
     "node_modules/cssdb": {
       "version": "7.11.2",
       "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.11.2.tgz",
@@ -6600,15 +6467,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -6722,12 +6580,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "license": "MIT"
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -9313,15 +9165,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -11322,15 +11165,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "license": "MIT",
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -11495,15 +11329,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/mini-css-extract-plugin": {
@@ -14195,19 +14020,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "license": "MIT",
-      "dependencies": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -15743,18 +15555,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "min-indent": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -16874,12 +16674,6 @@
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
       }
-    },
-    "node_modules/web-vitals": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.4.tgz",
-      "integrity": "sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg==",
-      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "axios": "^1.10.0",
-        "poker-hand-evaluator": "^1.0.1",
+        "pokersolver": "^2.1.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.7.0",
@@ -12115,10 +12115,13 @@
         "node": ">=4"
       }
     },
-    "node_modules/poker-hand-evaluator": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/poker-hand-evaluator/-/poker-hand-evaluator-1.0.1.tgz",
-      "integrity": "sha512-JJCLiRj3gV0goP8BoxdxXtyChDNCv0ABnZfX6dERND9lXC5gOr9ZoIy/AlTXb3/dEmjnJk+2O5HqgOpFA81pCQ==",
+    "node_modules/pokersolver": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/pokersolver/-/pokersolver-2.1.4.tgz",
+      "integrity": "sha512-vmgZS+K8H8r1RePQykFM5YyvlKo1v3xVec8FMBjg9N6mR2Tj/n/X415w+lG67FWbrk71D/CADmKFinDgaQlAsw==",
+      "engines": [
+        "node >= 4.0.0"
+      ],
       "license": "MIT"
     },
     "node_modules/possible-typed-array-names": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "axios": "^1.10.0",
+        "poker-hand-evaluator": "^1.0.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.7.0",
@@ -12113,6 +12114,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/poker-hand-evaluator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/poker-hand-evaluator/-/poker-hand-evaluator-1.0.1.tgz",
+      "integrity": "sha512-JJCLiRj3gV0goP8BoxdxXtyChDNCv0ABnZfX6dERND9lXC5gOr9ZoIy/AlTXb3/dEmjnJk+2O5HqgOpFA81pCQ==",
+      "license": "MIT"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "axios": "^1.10.0",
-    "poker-hand-evaluator": "^1.0.1",
+    "pokersolver": "^2.1.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.7.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "axios": "^1.10.0",
+    "poker-hand-evaluator": "^1.0.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.7.0",

--- a/package.json
+++ b/package.json
@@ -3,17 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@testing-library/dom": "^10.4.0",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.3.0",
-    "@testing-library/user-event": "^13.5.0",
     "axios": "^1.10.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.7.0",
     "react-scripts": "^5.0.1",
-    "socket.io-client": "^4.8.1",
-    "web-vitals": "^2.1.4"
+    "socket.io-client": "^4.8.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/GameShowdown.js
+++ b/src/components/GameShowdown.js
@@ -1,6 +1,16 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+import { evaluateWinners } from '../helpers/evaluatePokerHand';
 
 function GameShowdown({ showdownData, players }) {
+    const evaluatedPlayers = useMemo(() => {
+        if (!showdownData) return [];
+        const enrichedPlayers = players.map(p => ({
+            ...p,
+            hand: showdownData.hands[p.id] || []
+        }));
+        return evaluateWinners(enrichedPlayers, showdownData.communityCards);
+    }, [players, showdownData]);
+
     if (!showdownData) return null;
 
     return (
@@ -20,11 +30,17 @@ function GameShowdown({ showdownData, players }) {
             </div>
 
             <div className="players-hands">
-                {players.map(player => (
-                    <div key={player.id} className="player-hand-showdown">
-                        <p>{player.name}'s Hand:</p>
+                {evaluatedPlayers.map(player => (
+                    <div
+                        key={player.playerId}
+                        className={`player-hand-showdown ${player.isWinner ? 'winner' : ''}`}
+                    >
+                        <p>
+                            {player.name}'s Hand
+                            {player.isWinner && ' 🏆 Winner!'}
+                        </p>
                         <div>
-                            {(showdownData.hands[player.id] || []).map(card => (
+                            {player.hand.cards.map(card => (
                                 <img
                                     key={card.code}
                                     src={card.image}
@@ -33,6 +49,9 @@ function GameShowdown({ showdownData, players }) {
                                 />
                             ))}
                         </div>
+                        <p style={{ fontSize: '14px', color: '#ccc' }}>
+                            Combination: {player.hand.name}
+                        </p>
                     </div>
                 ))}
             </div>

--- a/src/components/PokerGameInProgress.js
+++ b/src/components/PokerGameInProgress.js
@@ -53,7 +53,6 @@ function PokerGameInProgress({
 
           <p>
             Your Chip Balance: {chipBalance}<br />
-            Current Bet Size to Call: {betSize}<br />
             Amount To Call: {toCall}<br />
             Total Pot: {pot}<br />
             Current Betting Round: {loopNum}

--- a/src/helpers/evaluatePokerHand.js
+++ b/src/helpers/evaluatePokerHand.js
@@ -1,0 +1,24 @@
+import evaluateHand from 'poker-hand-evaluator';
+
+export function evaluateWinners(players, communityCards) {
+  const hands = players.map(player => {
+    const fullHand = [...(player.hand || []), ...communityCards].map(card => ({
+      value: card.code[0],
+      suit: card.code[1].toUpperCase()
+    }));
+    
+    return {
+      playerId: player.id,
+      name: player.name,
+      handEval: evaluateHand(fullHand),
+    };
+  });
+
+  const bestRank = Math.min(...hands.map(h => h.handEval.rank));
+  const winners = hands.filter(h => h.handEval.rank === bestRank);
+
+  return hands.map(h => ({
+    ...h,
+    isWinner: winners.some(w => w.playerId === h.playerId)
+  }));
+}

--- a/src/helpers/evaluatePokerHand.js
+++ b/src/helpers/evaluatePokerHand.js
@@ -1,24 +1,24 @@
-import evaluateHand from 'poker-hand-evaluator';
+import PokerHand from 'poker-hand-evaluator';
 
-export function evaluateWinners(players, communityCards) {
-  const hands = players.map(player => {
-    const fullHand = [...(player.hand || []), ...communityCards].map(card => ({
-      value: card.code[0],
-      suit: card.code[1].toUpperCase()
-    }));
-    
+export default function evaluateWinners(players) {
+  const results = players.map(player => {
+    // Here, player.hand is a **space-separated string** of cards like "AD 3C AS 8C 8H 7H 4S"
+    const evalObj = new PokerHand(player.hand);
+
     return {
       playerId: player.id,
       name: player.name,
-      handEval: evaluateHand(fullHand),
+      rankScore: evalObj.getScore(),
+      rankName: evalObj.getRank(),
+      handName: evalObj.handName,
     };
   });
 
-  const bestRank = Math.min(...hands.map(h => h.handEval.rank));
-  const winners = hands.filter(h => h.handEval.rank === bestRank);
+  const bestScore = Math.min(...results.map(r => r.rankScore));
+  const winners = results.filter(r => r.rankScore === bestScore);
 
-  return hands.map(h => ({
-    ...h,
-    isWinner: winners.some(w => w.playerId === h.playerId)
+  return results.map(r => ({
+    ...r,
+    isWinner: winners.some(w => w.playerId === r.playerId),
   }));
 }

--- a/src/helpers/evaluatePokerHand.js
+++ b/src/helpers/evaluatePokerHand.js
@@ -1,24 +1,22 @@
-import PokerHand from 'poker-hand-evaluator';
+import { Hand } from 'pokersolver';
 
 export default function evaluateWinners(players) {
-  const results = players.map(player => {
-    // Here, player.hand is a **space-separated string** of cards like "AD 3C AS 8C 8H 7H 4S"
-    const evalObj = new PokerHand(player.hand);
-
+  const handsWithEval = players.map(player => {
+    const hand = Hand.solve(player.cards); // array of strings like ['Ad', 'Ks', ...]
+    
     return {
       playerId: player.id,
       name: player.name,
-      rankScore: evalObj.getScore(),
-      rankName: evalObj.getRank(),
-      handName: evalObj.handName,
+      rankName: hand.name,
+      handName: hand.descr,
+      solvedHand: hand
     };
   });
 
-  const bestScore = Math.min(...results.map(r => r.rankScore));
-  const winners = results.filter(r => r.rankScore === bestScore);
+  const winningHands = Hand.winners(handsWithEval.map(p => p.solvedHand));
 
-  return results.map(r => ({
-    ...r,
-    isWinner: winners.some(w => w.playerId === r.playerId),
+  return handsWithEval.map(p => ({
+    ...p,
+    isWinner: winningHands.includes(p.solvedHand)
   }));
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,16 +1,17 @@
 body {
   margin: 0;
+  padding: 0;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   background-color: #1e1e1e;
   color: white;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100vh;
 }
 
 .App {
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 20px;
 }
 
 input, button {
@@ -152,32 +153,62 @@ button:disabled {
 .showdown-container {
   text-align: center;
   margin-top: 40px;
+  padding: 0 20px;
+  max-width: 1000px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
 }
 
-.community-cards-on-table {
+/* COMMUNITY CARDS: single centered row */
+.community-cards-row {
   display: flex;
   justify-content: center;
-  gap: 10px;
-  margin-top: 20px;
-  margin-bottom: 30px;
+  gap: 12px;
+  flex-wrap: nowrap;
 }
 
-.players-hands {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  align-items: center;
-  max-height: 400px;
-  overflow-y: auto;
+.community-card-img {
+  width: 80px;
+  height: auto;
+  border-radius: 6px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.5);
 }
 
-.player-hand-showdown {
+/* PLAYERS CARDS: horizontal row, each player side by side */
+.players-cards-row {
+  display: flex;
+  justify-content: center;
+  gap: 40px;
+  flex-wrap: nowrap;
+  overflow-x: auto; /* optional: horizontal scroll if too many players */
+  padding-bottom: 10px;
+}
+
+.player-hand {
   display: flex;
   flex-direction: column;
   align-items: center;
+  min-width: 120px;
+}
+
+.player-hand.winner {
+  border: 2px solid gold;
+  box-shadow: 0 0 10px gold;
+  border-radius: 8px;
+  padding: 8px;
+}
+
+.player-cards {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
 }
 
 .player-hand-card {
-  width: 80px;
-  margin: 0 5px;
+  width: 60px;
+  height: auto;
+  border-radius: 4px;
+  box-shadow: 0 0 5px rgba(0,0,0,0.3);
 }


### PR DESCRIPTION
This PR will introduce the complete showdown phase of the poker game, including: 
 - Server logic to evaluate and broadcast all remaining players' hands.
 - UI updates to reveal all hands and community cards.
 - Message display for winning hand and chip distribution.
 - Countdown for transitioning to the next round automatically.

This builds upon the stable betting round logic introduced in the now merged into main and deleted branch ```poker-game-logic-and-card-displaying```.